### PR TITLE
修复bat运行时的乱码

### DIFF
--- a/Honkai_Star_Rail.bat
+++ b/Honkai_Star_Rail.bat
@@ -1,4 +1,4 @@
-﻿:: BatchGotAdmin (Run as Admin code starts)
+:: BatchGotAdmin (Run as Admin code starts)
 REM --> Check for permissions
 >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 REM --> If error flag set, we do not have admin.


### PR DESCRIPTION
`'锘?:' 不是内部或外部命令，也不是可运行的程序
或批处理文件。`(编码格式从UTF-8 BOM 改为 UTF-8)

![屏幕截图 2023-05-12 174633](https://github.com/Starry-Wind/Honkai-Star-Rail/assets/64072399/31ef178e-00a6-4c07-8d21-986cc7855fac)
