### PR TITLE
启动脚本中统一使用 python

### DIFF
--- a/Honkai_Star_Rail.bat
+++ b/Honkai_Star_Rail.bat
@@ -36,7 +36,7 @@ echo 自动依赖检查已完成
 echo.
 
 echo 正在自动更新地图档
-py Honkai_Star_Rail.py
+python Honkai_Star_Rail.py
 echo 在刚开启程序就看到这条信息? 你可能没有安装Python? 或是Python安装时没有勾选"Add Python to PATH"?
 echo 如果有可能是上面那些问题 请不要去Github回报issue或是来QQ群问这个问题 建议重新阅读Github页面的使用教学
 echo.


### PR DESCRIPTION
列出版本使用的是 python --version，但更新地图时使用的是 py。
个人测试windows 下在 Microsoft Store 中直接安装 python 3.11，只会存在 python 而不存在 py。