### PR TITLE
Add: 鼠标滚动支持

### DIFF
--- a/tool/calculated.py
+++ b/tool/calculated.py
@@ -171,6 +171,8 @@ class calculated:
                     time.sleep(1)
                 else:
                     raise Exception(f"map数据错误, fighting参数异常:{map_filename}", map)
+            elif key == "scroll":
+                self.scroll(value)
             else:
                 raise Exception(f"map数据错误,未匹配对应操作:{map_filename}", map)
 
@@ -189,3 +191,13 @@ class calculated:
         if last != 0:
             win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, last, 0)  # 进行视角移动
         time.sleep(0.5)
+       
+    def scroll(self, clicks: float):
+        """
+        说明：
+            控制鼠标滚轮滚动
+        参数：
+            :param clicks 滚动单位，正数为向上滚动
+        """
+        pyautogui.scroll(clicks)
+        time.sleep(.5)

--- a/tool/calculated.py
+++ b/tool/calculated.py
@@ -200,4 +200,4 @@ class calculated:
             :param clicks 滚动单位，正数为向上滚动
         """
         pyautogui.scroll(clicks)
-        time.sleep(.5)
+        time.sleep(0.5)


### PR DESCRIPTION
### 添加了什么？
添加了鼠标滚动支持

### 测试
本更改进行了本地测试。开发环境与 README 要求一致，使用 Python 3.11
测试时创建了一个地图文件：
```json
{
    "name": "Scroll test",
    "author": "5upernova-heng",
    "start": [],
    "map": [
        {
            "scroll": -100
        },
        {
            "scroll": -100
        },
        {
            "scroll": -100
        },
        {
            "scroll": 100
        },
        {
            "scroll": 100
        },
        {
            "scroll": 100
        }
    ]
}
```
在 `模拟宇宙-选择世界` 中测试，效果为先向下滚动三次，然后向上滚动三次，能够满足切换世界的需求
