### PR TITLE
Fix: 改用 questionary 库进行命令行选择

### DIFF
--- a/Honkai_Star_Rail.py
+++ b/Honkai_Star_Rail.py
@@ -5,7 +5,7 @@ try:
     import time
     import ctypes
     import pyuac
-    from pick import pick
+    import questionary
 
     from get_width import get_width
     from tools.config import read_json_file, modify_json_file, init_config_file, CONFIG_FILE_NAME
@@ -38,16 +38,16 @@ def main_start():
     if not read_json_file(CONFIG_FILE_NAME, False).get('start'):
         title = "请选择下载代理地址：（不使用代理选空白选项）"
         options = ['https://ghproxy.com/', 'https://ghproxy.net/', 'hub.fgit.ml', '']
-        option, index = pick(options, title, indicator='=>', default_index=0)
+        option = questionary(title, options)
         modify_json_file(CONFIG_FILE_NAME, "github_proxy", option)
         title = "请选择代理地址：（不使用代理选空白选项）"
         options = ['https://ghproxy.com/', 'https://ghproxy.net/', 'raw.fgit.ml', 'raw.iqiq.io', '']
-        option, index = pick(options, title, indicator='=>', default_index=0)
+        option = questionary(title, options)
         modify_json_file(CONFIG_FILE_NAME, "rawgithub_proxy", option)
         title = "你游戏里开启了连续自动战斗吗？："
         options = ['没打开', '打开了', '这是什么']
-        option, index = pick(options, title, indicator='=>', default_index=0)
-        modify_json_file(CONFIG_FILE_NAME, "auto_battle_persistence", index)
+        option = questionary(title, options)
+        modify_json_file(CONFIG_FILE_NAME, "auto_battle_persistence", options.index(option))
         modify_json_file(CONFIG_FILE_NAME, "start", True)
 
 def up_data():

--- a/Honkai_Star_Rail.py
+++ b/Honkai_Star_Rail.py
@@ -38,15 +38,15 @@ def main_start():
     if not read_json_file(CONFIG_FILE_NAME, False).get('start'):
         title = "请选择下载代理地址：（不使用代理选空白选项）"
         options = ['https://ghproxy.com/', 'https://ghproxy.net/', 'hub.fgit.ml', '']
-        option = questionary(title, options)
+        option = questionary.select(title, options).ask()
         modify_json_file(CONFIG_FILE_NAME, "github_proxy", option)
         title = "请选择代理地址：（不使用代理选空白选项）"
         options = ['https://ghproxy.com/', 'https://ghproxy.net/', 'raw.fgit.ml', 'raw.iqiq.io', '']
-        option = questionary(title, options)
+        option = questionary.select(title, options).ask()
         modify_json_file(CONFIG_FILE_NAME, "rawgithub_proxy", option)
         title = "你游戏里开启了连续自动战斗吗？："
         options = ['没打开', '打开了', '这是什么']
-        option = questionary(title, options)
+        option = questionary.select(title, options).ask()
         modify_json_file(CONFIG_FILE_NAME, "auto_battle_persistence", options.index(option))
         modify_json_file(CONFIG_FILE_NAME, "start", True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@ pynput
 
 aiohttp
 
-pick
+questionary
 
 pyuac


### PR DESCRIPTION
### 修改了什么
改用 [questionary](https://github.com/tmbo/questionary) 进行命令行选择，而不是 pick，这能解决中文挤在一起的问题。

### 测试
直接使用管理员启动中文 Windows 下的 cmd，就能打开 GBK 编码的古早命令行：

在这个命令行中，pick 的选择会出现中文挤在一起的问题，如图：
![image](https://github.com/Starry-Wind/Honkai-Star-Rail/assets/76626546/b6333979-0030-4e28-8f90-aa003c3b341e)

而 questionary 能很好兼容使用 GBK 编码的窗口：
![image](https://github.com/Starry-Wind/Honkai-Star-Rail/assets/76626546/ceda6751-a8c0-479a-8fa1-3377e3ac7e92)

